### PR TITLE
Incorporate yeast stater volume into equipment profile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+(Moves from Facebook)
+(My apologies if I'm entering this in the wrong space)
+Is it possible to add a feature in equipment profile to incorporate yeast volume to your batch volume? 
+This would mean the volume into the fermenter is X litres lower and gravity also varied to account for the dilution by the starter.
+Cheers


### PR DESCRIPTION
Is it possible to add a feature in equipment profile to incorporate yeast volume to your batch volume? 
This would mean the volume into the fermenter is X litres lower and gravity also varied to account for the dilution by the starter. 
Cheers